### PR TITLE
New plugins for aqtion-version of aq2admin

### DIFF
--- a/action/h_cvarbans.cfg
+++ b/action/h_cvarbans.cfg
@@ -1,0 +1,51 @@
+//
+// DO NOT CHANGE THIS FILE ON YOUR LOCAL SERVER, IT IS KEPT UPDATED AUTOMATICALLY
+// BY Q2ADMIN PLUGIN cvarbans.lua and AND YOUR CHANGES MIGHT GET OVERWRITTEN
+//
+// [ ! IMPORTANT !]
+// THIS FILE IS JUST FOR TESTING AT MOMENT AND IS NOT READY FOR PRODUCTION, PROPER VALUES AND
+// ACTIONS FOR CVARS NEEDS TO BE DISUSSED AND SET!!!
+//
+// usage:
+// addcvarban [cvar] [match] KICK [comment]
+// or
+// addcvarban [cvar] [match] STUFF [comment]${sc}_echo -c red [MESSAGE TO CLIENT]${sc}cvarbanlog-> [logmessage to server]
+//
+// If you want to add custom settings, create a file called h_cvarbans_costum.cfg
+// and store your custom settings there
+// 
+// if you need to add other settings, do so in other configs 
+// 
+
+// set current version
+sets cvarbans_version "2022-03-15"
+
+// delete all previous cvarbans
+delcvarban all
+
+// VISUALS
+addcvarban gl_modulate >5 STUFF gl_modulate 5${sc}_echo -c red gl_modulate is not allowed to be HIGHER than 5, fixing that for you sir${sc}cvarbanlog-> gl_modulate
+addcvarban gl_modulate_world >5 STUFF gl_modulate_world 5${sc}_echo -c red gl_modulate_world is not allowed to be HIGHER than 5, fixing that for you sir${sc}cvarbanlog-> gl_modulate_world
+addcvarban gl_modulate_entities >4 STUFF gl_modulate_entities 4${sc}_echo -c red gl_modulate_entities is not allowed to be HIGHER than 4, fixing that for you sir${sc}cvarbanlog-> gl_modulate_entities
+addcvarban gl_saturation <0.5 STUFF gl_saturation 0.5${sc}_echo -c red gl_saturation is not allowed to be LOWER than 0.5, fixing that for you sir${sc}cvarbanlog-> gl_saturation_low
+addcvarban gl_saturation >1 STUFF gl_saturation 1${sc}_echo -c red gl_saturation is not allowed to be HIGHER than 1, fixing that for you sir${sc}cvarbanlog-> gl_saturation_high
+addcvarban gl_picmip >2 STUFF gl_picmip 2${sc}_echo -c red gl_picmip is not allowed to be HIGHER than 2, fixing that for you sir${sc}cvarbanlog-> gl_picmip
+addcvarban gl_lockpvs !=0 KICK gl_lockpvs MUST be set to 0
+addcvarban gl_clear !=0 KICK gl_clear MUST be set to 0
+addcvarban gl_brightness >0.1 STUFF gl_brightness 0.1${sc}_echo -c red gl_brightness is not allowed to be HIGHER than 0.1, fixing that for you sir${sc}cvarbanlog-> gl_brightness
+addcvarban gl_novis !=1 STUFF gl_novis 1${sc}_echo -c yellow gl_novis MUST be set to 1, fixing that for you sir${sc}cvarbanlog-> gl_novis
+addcvarban vid_gamma <0 STUFF vid_gamma 0${sc}_echo -c red vid_gamma is not allowed to be LOWER than 0, fixing that for you sir${sc}cvarbanlog-> vid_gamma_low
+addcvarban vid_gamma >1 STUFF vid_gamma 1${sc}_echo -c red vid_gamma is not allowed to be HIGHER than 1, fixing that for you sir${sc}cvarbanlog-> vid_gamma_high
+addcvarban intensity <1 STUFF intensity 1${sc}_echo -c red intensity is not allowed to be LOWER than 1, fixing that for you sir${sc}cvarbanlog-> intensity_low
+addcvarban intensity >2 STUFF intensity 2${sc}_echo -c red intensity is not allowed to be HIGHER than 2, fixing that for you sir${sc}cvarbanlog-> intensity_high
+addcvarban r_hwGamma !=0 STUFF r_hwGamma 0${sc}_echo -c red r_hwGamma MUST be set to 0, fixing that for you sir${sc}cvarbanlog-> r_hwGamma
+
+// OTHER
+addcvarban cl_maxfps <20 STUFF cl_maxfps 20${sc}_echo -c red cl_maxfps is not allowed to be lower than 20, fixing that for you sir${sc}cvarbanlog-> cl_maxfps
+addcvarban cl_testblend !=0 STUFF 0${sc}_echo -c red cl_testblend MUST be set to 0, fixing that for you sir${sc}cvarbanlog-> cl_testblend
+addcvarban cl_blend !=1 STUFF cl_blend 1${sc}_echo -c red cl_blend MUST be set to 1, fixing that for you sir${sc}cvarbanlog-> cl_blend
+addcvarban cl_pitchspeed !=150 STUFF cl_pitchspeed 150${sc}_echo -c red cl_pitchspeed MUST be set to 150, fixing that for you sir${sc}cvarbanlog-> cl_pitchspeed
+
+// store your own cvarbans in this file!!!
+exec h_cvarbans_costum.cfg
+// EOL

--- a/plugins/cvarbans.lua
+++ b/plugins/cvarbans.lua
@@ -1,0 +1,97 @@
+--[[
+LUA script for downloading central cvarbanlist
+------------------------------
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+------------------------------
+Function:
+  automatically download centralized cvarbanlist from from GitHub
+
+TODO
+ - run "checkcvarbans" more often than default (on map change and client connect)?
+ - implement function to not run the updatescript to often and spam the url
+  (right now the update check runs on restart of server or \map xxx)
+------------------------------
+plugins = {
+    some_other_plugin = {
+        blah = "blah"
+    },
+    cvarbans = {
+        root_dir = '/home/aq2/aq2server/q2srv/',  -- rootdir of this server
+        url = 'https://raw.githubusercontent.com/actionquake/q2admin/master/action/h_cvarbans.cfg', -- url to download h_cvarbans.cfg
+    }, -- downloads and executes centralized cvarbanlist
+}
+------------------------------
+
+--]]
+
+local version = "1.0"
+local root_dir -- set this in config.lua
+local url -- set this in config.lua
+local cvarbans_update
+local game = gi.cvar("game", "").string
+
+function wait (millisecond)
+end
+ 
+gi.AddCommandString("sets q2a_cvarbans "..version.."\n")
+
+function cvarbans_os_exec(script)
+    os.execute(script)
+    wait(1000) -- wait 1s to make sure download is complete and went smooth
+    gi.AddCommandString("exec h_cvarbans.cfg\n") -- execute the file
+    local last_update = os.date()
+    gi.AddCommandString('sets cvarbans_update '..last_update..'\n') -- write update time to cvar
+end
+
+function checkcvarbans()
+    gi.AddCommandString("checkcvarbans\n")
+    gi.dprintf("checking all clients cvars\n")
+end
+
+-- log illegal cvar settings
+function ClientCommand(client)
+  if(gi.argv(1) == 'cvarbanlog->') then
+      local plr = ex.players[client]
+      local ip = string.match(plr.ip, '^([^:]+)')
+      local now = os.time()
+      local logmsg = gi.argv(2).." "..gi.argv(3).." "..gi.argv(4).." "..gi.argv(5).." "..gi.argv(6).." "..gi.argv(7).." "..gi.argv(8).." "..gi.argv(9)
+      if gi.argc() == 1 then
+        return false
+      else
+        gi.dprintf("[cvarbans.lua] [%s (%s)] "..logmsg.." \n", ex.players[client].name, ex.players[client].ip)
+        return true
+      end
+      return false
+  end
+  return false
+end
+
+function q2a_load(config)
+  gi.dprintf("cvarbans.lua q2a_load(): "..version.." for Action Quake 2 loaded.\n")
+  
+  root_dir = config.root_dir
+  url = config.url
+  if root_dir == nil then
+    gi.dprintf("cvarbans.lua q2a_load(): 'root_dir' not defined in the config.lua file... aborting\n")
+    return 0
+  end
+  if url == nil then
+    gi.dprintf("cvarbans.lua q2a_load(): 'url' not defined in the config.lua file... aborting\n")
+    return 0
+  end
+
+  gi.dprintf("cvarbans.lua q2a_load(): Checking/Downloading new cvarbans... ")
+  cvarbans_update = root_dir..'plugins/cvarbans_update.sh  "'..url..'" "'..game..'"'
+  cvarbans_os_exec(cvarbans_update) -- check for updated cvarbanlist on load
+end

--- a/plugins/cvarbans_update.sh
+++ b/plugins/cvarbans_update.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/bash
+# a script that checks and downloads of the cvarbans master file
+
+# download URL
+url="$1"
+gamedir="$2"
+# bypass modsecurity
+usaragent="-d --user-agent=cvarbans-update-script"
+# parse the filename from the download path
+filename=$(echo $url | sed -n 's/^\(.*\/\)*\(.*\)/\2/p')
+
+# script to download latest h_cvarbans.cfg from github
+cd "${0%/*}"    # cd to current dir
+cd ../$gamedir/   # cd back and to game dir
+
+#### script
+# download the file if updated since last time, and output wheter it updated or not to console
+
+if [[ "$url" == *"githubusercontent"* ]]; then
+  # not using -N switch for wget since github does not support "last update" parameter, the file will be downloaded on every check, wich is not optimal
+  wget -O $filename $url 2>&1 | tee | grep -E 'Omitting download|‘h_cvarbans.cfg’ saved|ERROR 404: Not Found'
+else
+  # using -N switch for wget since the file os not hosted on github, best solution, since file will only be downloaded if changed
+  wget $usaragent -N $url 2>&1 | tee | grep -E 'Omitting download|‘h_cvarbans.cfg’ saved|ERROR 404: Not Found'
+fi
+
+exit

--- a/plugins/download_new_maplist.sh
+++ b/plugins/download_new_maplist.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# set this file to run periodically in crontab to let it download
+# and update the latest maplists from www.aq2.eu/votemap
+#
+
+#### variables
+# download URL
+uri="https://www.aq2.eu/votemap/public.ini"
+# parse the filename from the download path
+file=$(echo $uri | sed -n 's/^\(.*\/\)*\(.*\)/\2/p')
+# where to copy the downloaded file
+dst="/home/aq2/aq2server/q2srv/action/config/public.ini"
+# bypass Fragbaits modsecurity
+usaragent="-d --user-agent=refresh-action.ini-script"
+# Screen names of the servers you want to send sv_recycle to
+screens=( gs1 gs2 gs3 )
+
+#### script
+# download the file if updated since last time
+wget $usaragent -N $uri
+
+# copy the file to the correct destination (if changed since last time)
+# first check if the online file is newer than the local
+dwnldfile_ctime=$(stat -c %z "$file")
+dwnldfile_ctime=$(date --date="$dwnldfile_ctime" +%s)
+dstfile_ctime=$(stat -c %z "$dst")
+dstfile_ctime=$(date --date="$dstfile_ctime" +%s)
+echo $dwnldfile_ctime
+echo $dstfile_ctime
+if (( $dstfile_ctime < $dwnldfile_ctime )); then
+   echo "updating file"
+   cp $file $dst
+   
+   #tell the server to restart on next map change
+   for i in "${screens[@]}"
+   do
+      screen -S $i -X stuff "sv_recycle 1
+      say [ Maplist updated ]^M"
+   done
+else
+   echo "not updating file"
+fi

--- a/plugins/public.lua
+++ b/plugins/public.lua
@@ -1,0 +1,133 @@
+--[[
+LUA script for improving public AQ2 server experience
+------------------------------
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+------------------------------
+Function:
+   change serversettings to make it more fun to wait for more players
+   to join the server
+------------------------------
+
+--]]
+local version = "1.0"
+local delay = 5                                         -- delay before message and settings are run
+local teamplay = gi.cvar("teamplay", "").string         -- check if the server has cvar teamplay 1 or 0
+local sendMsg = false
+local changeDmflags
+local SendMsgAt
+local plrInBothTeams
+if dmflags_bak ~= '' or nil then
+    local dmflags_bak = gi.cvar("dmflags", "").string       -- store dmflagssetting
+end
+local dmflags_now
+local msg = {}
+
+local test = gi.cvar("asdf", "").string
+gi.dprintf("public.lua test = " .. test .. "\n")
+
+function override_dmflags()
+    dmflags_bak = gi.cvar("dmflags_bak", "").string
+    if dmflags_now ~= 8 then                            -- set dmflags to 8 if it isn't already
+        gi.AddCommandString("sets dmflags 8\n")
+        gi.dprintf("public.lua: setdmflags_dm() dmflags set to 8 (default: "..dmflags_bak..")\n")
+    end
+end
+
+function restore_dmflags()
+    if dmflags_now ~= dmflags_bak or dmflags_bak == '' then 
+        gi.AddCommandString("sets dmflags "..dmflags_bak.."\n")
+        gi.dprintf("public.lua: setdmflags_dm() dmflags set back to "..dmflags_bak.."\n")
+    end
+end
+
+function setdmflags()
+    dmflags_now = gi.cvar("dmflags", "").string
+    if teamplay == "0" then
+        local plrcount = #ex.players
+        if plrcount == 1 then
+            override_dmflags()
+            for i=1, #msg do msg[i] = nil end -- empty msg table before storing new messages
+            msg[1] = '* * * You are alone on this server * * *\n'
+            msg[2] = '* * * I\'ve disabled fall damage again so you can fool around while you wait for someone to join <3 * * *\n'
+            sendMsg = true
+            SendMsgAt = os.time() + delay
+        elseif plrcount > 1 and dmflags_now ~= dmflags_bak then
+            restore_dmflags()
+            for i=1, #msg do msg[i] = nil end -- empty msg table before storing new messages
+            msg[1] = '* * * WOHOO, you are now atleast two players, ACTION! * * *\n'
+            sendMsg = true
+            SendMsgAt = os.time() + delay
+        end
+    elseif teamplay == "1" then
+        if not plrInBothTeams then
+            override_dmflags()
+            for i=1, #msg do msg[i] = nil end -- empty msg table before storing new messages
+            msg[1] = '* * * There are not players in both teams * * *\n'
+            msg[2] = '* * * I\'ve disabled fall damage so you can fool around while you wait * * *\n'
+            sendMsg = true
+            SendMsgAt = os.time() + delay
+        elseif plrInBothTeams then
+            restore_dmflags()
+            for i=1, #msg do msg[i] = nil end -- empty msg table before storing new messages
+            msg[1] = '* * * Both teams has players, ACTION * * *\n'
+            sendMsg = true
+            SendMsgAt = os.time() + delay
+        end
+    end
+end
+
+function LogMessage(msg)
+    local name = string.match(msg, "(.+) entered the game")
+    if name ~= nil then
+        name = nil
+        setdmflags()
+    end
+    local name = string.match(msg, "(.+) disconnected")
+    if name ~= nil then
+        name = nil
+        setdmflags()
+    end
+    local name = string.match(msg, "The round will begin in (.+) seconds!")
+    if name ~= nil then
+        name = nil
+        plrInBothTeams = true
+        setdmflags()
+    end
+    local name = string.match(msg, "Not enough players to play!")
+    if name ~= nil then
+        name = nil
+        plrInBothTeams = false
+        setdmflags()
+    end
+end
+
+function RunFrame()
+    if sendMsg then
+        if SendMsgAt <= os.time() then
+            for i=1, #msg do
+                gi.bprintf(PRINT_CHAT, msg[i])
+                msg[i] = nil
+            end
+            sendMsg = false
+        end
+    end
+end
+
+function q2a_load(config)
+    gi.dprintf("public.lua: q2a_load(): "..version.." for Action Quake 2 loaded.\n")
+end
+
+function q2a_unload(config)
+    gi.dprintf("public.lua: q2a_load(): setting dmflags back to default ("..dmflags_bak..")\n")
+end


### PR DESCRIPTION
Here are my own plugins for q2admin.
[plugins/cvarbans.lua](https://github.com/actionquake/q2admin/compare/aqtion...ndit-dev:aqtion#diff-b8cea8e4c8b0eb0f6ca67dfa5c3dee2b8724c0dde9ec93c13b3d64b960f283bb) is a script that downloads a centrally held list of illegal cvars and logs players using bad values, as well as stuffcmd or kicks players with bad values. It is working fine, but the actual values for cvarbans needs to be reviewed and decided by the mods and serveradmins. Until these values are set it is not ready for production. But I think this is a good function to have on all official servers!

[plugins/cvarbans_update.sh](https://github.com/actionquake/q2admin/compare/aqtion...ndit-dev:aqtion#diff-9494b37eaccc72559fe667375073dea21796c2a44a084ca24486daa698d39c71) isn't really  a plugin, but a bashscript that automagically downloads maplists from fragbaits votingsystem on his site. Enabling the community to vote for what maps to be used in rotation on the server. This is active on the aq2.eu-servers 

[plugins/public.lua](https://github.com/actionquake/q2admin/compare/aqtion...ndit-dev:aqtion#diff-fe9024aaa2213ca2169df3e944f38ec6c3766af6113828310fb661fcb8df2aae) is a script ment to make it more fun to be alone on a server. Right now, the only thing it does is setting dmflags to 8 (disabling fall damage) as long as you are alone on DM-servers or as long as not bot team has players in teamplay. The thought behind this script is to make people staying longer on empty servers in the wait for others to join.