### PR TITLE
Changed sets to set

### DIFF
--- a/plugins/broadcast.lua
+++ b/plugins/broadcast.lua
@@ -7,7 +7,7 @@
 
 -- setup
 local version = "1.0"
-gi.AddCommandString("sets q2a_broadcast "..version.."\n")
+gi.AddCommandString("set q2a_broadcast "..version.."\n")
 gi.cvar_set("broadcast", "")
 
 

--- a/plugins/clip.lua
+++ b/plugins/clip.lua
@@ -19,7 +19,7 @@ function q2a_load()
 	gi.dprintf("q2client version "..version.." script loaded\n")
 end
 
-gi.AddCommandString("sets q2a_clip "..version.."\n")
+gi.AddCommandString("set q2a_clip "..version.."\n")
 
 local file
 local fileStr

--- a/plugins/coinflip.lua
+++ b/plugins/coinflip.lua
@@ -3,7 +3,7 @@
 ---
 
 local version = "1.0"
-gi.AddCommandString("sets q2a_cointoss "..version.."\n")
+gi.AddCommandString("set q2a_cointoss "..version.."\n")
 
 -- edit this (seconds)
 local flip_flood = 5

--- a/plugins/cvarbans.lua
+++ b/plugins/cvarbans.lua
@@ -44,7 +44,7 @@ local game = gi.cvar("game", "").string
 function wait (millisecond)
 end
  
-gi.AddCommandString("sets q2a_cvarbans "..version.."\n")
+gi.AddCommandString("set q2a_cvarbans "..version.."\n")
 
 function cvarbans_os_exec(script)
     os.execute(script)

--- a/plugins/lrcon.lua
+++ b/plugins/lrcon.lua
@@ -7,7 +7,7 @@
 -- 1.1 fixed sv softmap and sv stuffall and maybe lrcon status crash
 
 local version = "1.3"
-gi.AddCommandString("sets q2a_lrcon "..version.."\n")
+gi.AddCommandString("set q2a_lrcon "..version.."\n")
 
 local quit_on_empty 
 local cvars

--- a/plugins/mvd.lua
+++ b/plugins/mvd.lua
@@ -61,7 +61,7 @@ end
 -- if we came to here, it's action!
 
 local version = "1.6hau"
-gi.AddCommandString("sets q2a_mvd "..version.."\n")
+gi.AddCommandString("set q2a_mvd "..version.."\n")
 
 local mvd_webby -- configure this one in the config.lua
 local exec_script_on_system_after_recording -- configure this one in the config.lua

--- a/plugins/mvd2cprints.lua
+++ b/plugins/mvd2cprints.lua
@@ -10,7 +10,7 @@ e.g.
 
 local mvdfix = 1
 function q2a_load()
-    gi.AddCommandString("sets q2a_mvd2cprints "..mvdfix.."\n")
+    gi.AddCommandString("set q2a_mvd2cprints "..mvdfix.."\n")
 end
 
 function LogMessage(msg)

--- a/plugins/version.lua
+++ b/plugins/version.lua
@@ -19,7 +19,7 @@ simple !version* script by TgT
 local version = "2.2"
 local word = "!versio.+"
 
-gi.AddCommandString("sets q2a_version "..version.."\n")
+gi.AddCommandString("set q2a_version "..version.."\n")
 gi.AddCommandString("addstuffcmd begin set version 0 u\n")
 
 function ClientCommand(client)


### PR DESCRIPTION
Serverinfo has a single packet to deliver as much data as possible to the master servers.  If we rely on this data at some point, we'll need to drop some of the extraneous stuff we don't necessarily need.  This will keep the cvars intact, but not as SERVERINFO