### PR TITLE
Added automatic checking, darkmatch settings, etc

### DIFF
--- a/action/darkmatch.cfg
+++ b/action/darkmatch.cfg
@@ -11,17 +11,12 @@
 // or
 // addcvarban [cvar] [match] STUFF [comment]${sc}_echo -c red [MESSAGE TO CLIENT]${sc}cvarbanlog-> [logmessage to server]
 //
-// If you want to add custom settings, create a file called h_cvarbans_custom.cfg
-// and store your custom settings there
 // 
 // if you need to add other settings, do so in other configs 
 // 
 
 // set current version
-sets cvarbans_version "2022-03-15"
-
-// delete all previous cvarbans
-delcvarban all
+sets cvarbans_version "2023-12-04"
 
 // VISUALS
 addcvarban gl_modulate >5 STUFF gl_modulate 5${sc}_echo -c red gl_modulate is not allowed to be HIGHER than 5, fixing that for you sir${sc}cvarbanlog-> gl_modulate
@@ -32,18 +27,12 @@ addcvarban gl_saturation >1 STUFF gl_saturation 1${sc}_echo -c red gl_saturation
 addcvarban gl_picmip >2 STUFF gl_picmip 2${sc}_echo -c red gl_picmip is not allowed to be HIGHER than 2, fixing that for you sir${sc}cvarbanlog-> gl_picmip
 addcvarban gl_lockpvs !=0 KICK gl_lockpvs MUST be set to 0
 addcvarban gl_clear !=0 KICK gl_clear MUST be set to 0
-addcvarban gl_brightness >0.1 STUFF gl_brightness 0.1${sc}_echo -c red gl_brightness is not allowed to be HIGHER than 0.1, fixing that for you sir${sc}cvarbanlog-> gl_brightness
+addcvarban gl_brightness !=0 STUFF gl_brightness 0${sc}_echo -c red gl_brightness must be 0 for darkmatch, fixing that for you sir${sc}cvarbanlog-> gl_brightness
 addcvarban gl_novis !=1 STUFF gl_novis 1${sc}_echo -c yellow gl_novis MUST be set to 1, fixing that for you sir${sc}cvarbanlog-> gl_novis
 addcvarban vid_gamma <0 STUFF vid_gamma 0${sc}_echo -c red vid_gamma is not allowed to be LOWER than 0, fixing that for you sir${sc}cvarbanlog-> vid_gamma_low
 addcvarban vid_gamma >1 STUFF vid_gamma 1${sc}_echo -c red vid_gamma is not allowed to be HIGHER than 1, fixing that for you sir${sc}cvarbanlog-> vid_gamma_high
 addcvarban intensity <1 STUFF intensity 1${sc}_echo -c red intensity is not allowed to be LOWER than 1, fixing that for you sir${sc}cvarbanlog-> intensity_low
 addcvarban intensity >2 STUFF intensity 2${sc}_echo -c red intensity is not allowed to be HIGHER than 2, fixing that for you sir${sc}cvarbanlog-> intensity_high
 addcvarban r_hwGamma !=0 STUFF r_hwGamma 0${sc}_echo -c red r_hwGamma MUST be set to 0, fixing that for you sir${sc}cvarbanlog-> r_hwGamma
-
-// OTHER
-addcvarban cl_maxfps <20 STUFF cl_maxfps 20${sc}_echo -c red cl_maxfps is not allowed to be lower than 20, fixing that for you sir${sc}cvarbanlog-> cl_maxfps
-addcvarban cl_testblend !=0 STUFF 0${sc}_echo -c red cl_testblend MUST be set to 0, fixing that for you sir${sc}cvarbanlog-> cl_testblend
-addcvarban cl_blend !=1 STUFF cl_blend 1${sc}_echo -c red cl_blend MUST be set to 1, fixing that for you sir${sc}cvarbanlog-> cl_blend
-addcvarban cl_pitchspeed !=150 STUFF cl_pitchspeed 150${sc}_echo -c red cl_pitchspeed MUST be set to 150, fixing that for you sir${sc}cvarbanlog-> cl_pitchspeed
 
 // EOL

--- a/action/force_xerp.cfg
+++ b/action/force_xerp.cfg
@@ -1,0 +1,23 @@
+//
+// DO NOT CHANGE THIS FILE ON YOUR LOCAL SERVER, IT IS KEPT UPDATED AUTOMATICALLY
+// BY Q2ADMIN PLUGIN cvarbans.lua and AND YOUR CHANGES MIGHT GET OVERWRITTEN
+//
+// [ ! IMPORTANT !]
+// THIS FILE IS JUST FOR TESTING AT MOMENT AND IS NOT READY FOR PRODUCTION, PROPER VALUES AND
+// ACTIONS FOR CVARS NEEDS TO BE DISUSSED AND SET!!!
+//
+// usage:
+// addcvarban [cvar] [match] KICK [comment]
+// or
+// addcvarban [cvar] [match] STUFF [comment]${sc}_echo -c red [MESSAGE TO CLIENT]${sc}cvarbanlog-> [logmessage to server]
+//
+// 
+// if you need to add other settings, do so in other configs 
+// 
+
+// set current version
+sets cvarbans_version "2023-12-04"
+
+addcvarban cl_xerp =1 STUFF cl_xerp 2${sc}_echo -c red cl_xerp is not allowed to be set to 1, fixing that for you sir${sc}cvarbanlog-> cl_xerp
+
+// EOL

--- a/plugins/cvarbans.lua
+++ b/plugins/cvarbans.lua
@@ -56,7 +56,7 @@ end
 
 function checkcvarbans()
     gi.AddCommandString("checkcvarbans\n")
-    gi.dprintf("checking all clients cvars\n")
+    --gi.dprintf("checking all clients cvars\n")
 end
 
 -- log illegal cvar settings
@@ -82,6 +82,7 @@ function q2a_load(config)
   
   root_dir = config.root_dir
   url = config.url
+  check_interval = config.check_interval or 10 -- default 10 seconds
   if root_dir == nil then
     gi.dprintf("cvarbans.lua q2a_load(): 'root_dir' not defined in the config.lua file... aborting\n")
     return 0
@@ -90,8 +91,26 @@ function q2a_load(config)
     gi.dprintf("cvarbans.lua q2a_load(): 'url' not defined in the config.lua file... aborting\n")
     return 0
   end
+  if check_interval == nil then
+    gi.dprintf("cvarbans.lua q2a_load(): 'check_interval' not defined in the config.lua file... using default 10 seconds\n")
+  elseif check_interval == '0' or tonumber(check_interval) == 0 then
+    gi.dprintf("cvarbans.lua q2a_load(): 'check_interval' set to 0 seconds... disabling automatic cvarbans checking\n")
+  else
+    gi.dprintf("cvarbans.lua q2a_load(): 'check_interval' set to "..check_interval.." seconds\n")
+  end
 
   gi.dprintf("cvarbans.lua q2a_load(): Checking/Downloading new cvarbans... ")
   cvarbans_update = root_dir..'plugins/cvarbans_update.sh  "'..url..'" "'..game..'"'
   cvarbans_os_exec(cvarbans_update) -- check for updated cvarbanlist on load
+end
+
+local last_check = os.time()
+
+function RunFrame()
+    local now = os.time()
+
+    if tonumber(check_interval) > 0 and now - last_check >= tonumber(check_interval) then
+        checkcvarbans()
+        last_check = now
+    end
 end


### PR DESCRIPTION
- Added cvar ban lists for darkmatch and force_xerp
- Made `cvarbans_update.sh` executable
- Added option `check_interval` which checks all cvar settings loaded via addcvarban every X seconds based on value provided
  - Omission of this option defaults it to 10 seconds
  - Setting it to '0' disables automatic checking while still loading cvar bans
